### PR TITLE
FEAT Create preferential ranking question

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@creativebulma/bulma-collapsible": "~1.0.4",
+        "@dnd-kit/core": "^6.0.8",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~13.5.0",
@@ -2247,6 +2248,42 @@
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz",
+      "integrity": "sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.8.tgz",
+      "integrity": "sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA==",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.0.0",
+        "@dnd-kit/utilities": "^3.2.1",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.1.tgz",
+      "integrity": "sha512-OOXqISfvBw/1REtkSK2N3Fi2EQiLMlWUlqnOK/UpOISqBZPWpE6TqL+jcPtMOkE8TqYGiURvRdPSI9hltNUjEA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -20723,6 +20760,32 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="
+    },
+    "@dnd-kit/accessibility": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz",
+      "integrity": "sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/core": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.8.tgz",
+      "integrity": "sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA==",
+      "requires": {
+        "@dnd-kit/accessibility": "^3.0.0",
+        "@dnd-kit/utilities": "^3.2.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/utilities": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.1.tgz",
+      "integrity": "sha512-OOXqISfvBw/1REtkSK2N3Fi2EQiLMlWUlqnOK/UpOISqBZPWpE6TqL+jcPtMOkE8TqYGiURvRdPSI9hltNUjEA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     },
     "@emotion/babel-plugin": {
       "version": "11.10.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@creativebulma/bulma-collapsible": "~1.0.4",
         "@dnd-kit/core": "^6.0.8",
+        "@dnd-kit/modifiers": "^6.0.1",
+        "@dnd-kit/sortable": "^7.0.2",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~13.5.0",
@@ -2273,6 +2275,32 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-6.0.1.tgz",
+      "integrity": "sha512-rbxcsg3HhzlcMHVHWDuh9LCjpOVAgqbV78wLGI8tziXY3+qcMQ61qVXIvNKQFuhj75dSfD+o+PYZQ/NUk2A23A==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.1",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.0.6",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.2.tgz",
+      "integrity": "sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.0.7",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/utilities": {
@@ -20776,6 +20804,24 @@
       "requires": {
         "@dnd-kit/accessibility": "^3.0.0",
         "@dnd-kit/utilities": "^3.2.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/modifiers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-6.0.1.tgz",
+      "integrity": "sha512-rbxcsg3HhzlcMHVHWDuh9LCjpOVAgqbV78wLGI8tziXY3+qcMQ61qVXIvNKQFuhj75dSfD+o+PYZQ/NUk2A23A==",
+      "requires": {
+        "@dnd-kit/utilities": "^3.2.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/sortable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.2.tgz",
+      "integrity": "sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==",
+      "requires": {
+        "@dnd-kit/utilities": "^3.2.0",
         "tslib": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "dependencies": {
     "@creativebulma/bulma-collapsible": "~1.0.4",
     "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/modifiers": "^6.0.1",
+    "@dnd-kit/sortable": "^7.0.2",
     "@testing-library/jest-dom": "~5.16.5",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~13.5.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "proxy": "http://localhost:8000",
   "dependencies": {
     "@creativebulma/bulma-collapsible": "~1.0.4",
+    "@dnd-kit/core": "^6.0.8",
     "@testing-library/jest-dom": "~5.16.5",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~13.5.0",

--- a/src/pages/Admin/CreateQuestion.js/component/QuestionTypeSelector.jsx
+++ b/src/pages/Admin/CreateQuestion.js/component/QuestionTypeSelector.jsx
@@ -16,7 +16,7 @@ export default function QuestionTypeSelector({
               {/* <option value="open_question">Pregunta abierta</option> */}
               <option value="closed_question">Pregunta cerrada</option>
               <option value="mixnet_question">Pregunta mixnet</option>
-              <option value="stv_question">Pregunta con ranking preferencial</option>
+              <option value="stvnc_question">Pregunta con ranking preferencial</option>
             </select>
           </div>
         </div>

--- a/src/pages/Admin/CreateQuestion.js/component/QuestionTypeSelector.jsx
+++ b/src/pages/Admin/CreateQuestion.js/component/QuestionTypeSelector.jsx
@@ -16,6 +16,7 @@ export default function QuestionTypeSelector({
               {/* <option value="open_question">Pregunta abierta</option> */}
               <option value="closed_question">Pregunta cerrada</option>
               <option value="mixnet_question">Pregunta mixnet</option>
+              <option value="stv_question">Pregunta con ranking preferencial</option>
             </select>
           </div>
         </div>

--- a/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
@@ -10,6 +10,7 @@ import MixnetSelection from "./MixnetSelection";
 import InputSelection from "./InputSelection";
 import { answersRestrictionText } from "./utils.js";
 import { permanentOptionsList } from "../../../../constants";
+import RankingSelection from "./RankingSelection";
 
 function QuestionElection(props) {
   /** Component for election questions */
@@ -104,7 +105,7 @@ function QuestionElection(props) {
             <div className="box has-text-left question-box has-text-white is-flex is-justify-content-center mb-3">
               <div className="control control-box">
                 {question.q_type === "closed_question" && (
-                  <InputSelection
+                  <RankingSelection
                     index={index}
                     addAnswer={addAnswer}
                     question={question}

--- a/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
@@ -7,10 +7,10 @@ import QuestionHeader from "./QuestionHeader";
 import ModalPercentage from "../../components/ModalPercentage";
 import AlertQuestions from "./Questions/AlertQuestions";
 import MixnetSelection from "./MixnetSelection";
-// import InputSelection from "./InputSelection";
 import { answersRestrictionText } from "./utils.js";
 import { permanentOptionsList } from "../../../../constants";
 import RankingSelection from "./RankingSelection";
+import InputSelection from "./InputSelection";
 
 function QuestionElection(props) {
   /** Component for election questions */
@@ -105,7 +105,7 @@ function QuestionElection(props) {
             <div className="box has-text-left question-box has-text-white is-flex is-justify-content-center mb-3">
               <div className="control control-box">
                 {question.q_type === "closed_question" && (
-                  <RankingSelection
+                  <InputSelection
                     index={index}
                     addAnswer={addAnswer}
                     question={question}

--- a/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
@@ -7,7 +7,7 @@ import QuestionHeader from "./QuestionHeader";
 import ModalPercentage from "../../components/ModalPercentage";
 import AlertQuestions from "./Questions/AlertQuestions";
 import MixnetSelection from "./MixnetSelection";
-import InputSelection from "./InputSelection";
+// import InputSelection from "./InputSelection";
 import { answersRestrictionText } from "./utils.js";
 import { permanentOptionsList } from "../../../../constants";
 import RankingSelection from "./RankingSelection";

--- a/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
@@ -104,8 +104,7 @@ function QuestionElection(props) {
 
             <div className="box has-text-left question-box has-text-white is-flex is-justify-content-center mb-3">
               <div className="control control-box">
-                {question.q_type === "stvnc_question" &&
-                  !question.include_blank_null && (
+                {question.q_type === "stvnc_question" && (
                     <RankingSelection
                       index={index}
                       addAnswer={addAnswer}

--- a/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
@@ -104,6 +104,15 @@ function QuestionElection(props) {
 
             <div className="box has-text-left question-box has-text-white is-flex is-justify-content-center mb-3">
               <div className="control control-box">
+                {question.q_type === "stv_question" &&
+                  !question.include_blank_null && (
+                    <RankingSelection
+                      index={index}
+                      addAnswer={addAnswer}
+                      question={question}
+                      election={props.election}
+                    />
+                )}
                 {question.q_type === "closed_question" && (
                   <InputSelection
                     index={index}

--- a/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
@@ -104,7 +104,7 @@ function QuestionElection(props) {
 
             <div className="box has-text-left question-box has-text-white is-flex is-justify-content-center mb-3">
               <div className="control control-box">
-                {question.q_type === "stv_question" &&
+                {question.q_type === "stvnc_question" &&
                   !question.include_blank_null && (
                     <RankingSelection
                       index={index}

--- a/src/pages/Booth/Election/QuestionSection/Questions/InputRadio.jsx
+++ b/src/pages/Booth/Election/QuestionSection/Questions/InputRadio.jsx
@@ -1,4 +1,5 @@
 function InputRadio(props) {
+  console.log(props.answers);
   function handlerInput(event) {
     props.setAnswers([parseInt(event.target.value)]);
     props.setBlankButton(false);

--- a/src/pages/Booth/Election/QuestionSection/Questions/InputRadio.jsx
+++ b/src/pages/Booth/Election/QuestionSection/Questions/InputRadio.jsx
@@ -1,5 +1,4 @@
 function InputRadio(props) {
-  console.log(props.answers);
   function handlerInput(event) {
     props.setAnswers([parseInt(event.target.value)]);
     props.setBlankButton(false);

--- a/src/pages/Booth/Election/QuestionSection/Questions/InputRanking.jsx
+++ b/src/pages/Booth/Election/QuestionSection/Questions/InputRanking.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import {
   DndContext,
@@ -21,14 +21,19 @@ import {
   restrictToWindowEdges,
 } from "@dnd-kit/modifiers";
 
+import { SortableItem } from "./SortableItem";
+
 /**
- * 
- * @param {*} props 
- * @returns 
+ *
+ * @param {*} props
+ * @returns
  */
 const InputRanking = (props) => {
-  /** @state */
-  const [items, setItems] = useState([1, 2, 3]);
+  // dnd-kit sortable ids start from 1.
+  let rankingOptions = props.answers.map((id) => id + 1);
+  let rankingIndices = Array.from(rankingOptions.keys()).map((id) => id + 1);
+  console.log(props.answers);
+
   /** @sensors */
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -44,27 +49,47 @@ const InputRanking = (props) => {
   const handleDragEnd = (event) => {
     const { active, over } = event;
     if (active.id !== over.id) {
-      setItems((items) => {
-        const oldIndex = items.indexOf(active.id);
-        const newIndex = items.indexOf(over.id);
-        return arrayMove(items, oldIndex, newIndex);
+      props.setAnswers((answers) => {
+        const oldIndex = answers.indexOf(active.id - 1);
+        const newIndex = answers.indexOf(over.id - 1);
+        return arrayMove(answers, oldIndex, newIndex);
+        // TODO: modify QuestionElection answers as well for encryption.
       });
     }
   };
 
   return (
-    <DndContext
-      sensors={sensors}
-      collisionDetection={closestCenter}
-      onDragEnd={handleDragEnd}
-      modifiers={[restrictToVerticalAxis, restrictToWindowEdges]}
-    >
-      <SortableContext items={items} strategy={verticalListSortingStrategy}>
-        {items.map((id) => (
-          <SortableItem key={id} id={id} />
+    <div className="ranking__container">
+      <div className="ranking__idx_col">
+        {rankingIndices.map((id) => (
+          <div className="ranking__idx" key={id}>
+            {id}°
+          </div>
         ))}
-      </SortableContext>
-    </DndContext>
+      </div>
+      <div className="ranking__opt_col">
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+          modifiers={[restrictToVerticalAxis, restrictToWindowEdges]}
+        >
+          <SortableContext
+            items={rankingOptions}
+            strategy={verticalListSortingStrategy}
+          >
+            {rankingOptions.map((id) => (
+              <SortableItem
+                className="ranking__btn"
+                content={props.question.closed_options[id - 1]}
+                id={id}
+                key={id}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
+      </div>
+    </div>
   );
 };
 

--- a/src/pages/Booth/Election/QuestionSection/Questions/InputRanking.jsx
+++ b/src/pages/Booth/Election/QuestionSection/Questions/InputRanking.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+
+import {
+  restrictToVerticalAxis,
+  restrictToWindowEdges,
+} from "@dnd-kit/modifiers";
+
+/**
+ * 
+ * @param {*} props 
+ * @returns 
+ */
+const InputRanking = (props) => {
+  /** @state */
+  const [items, setItems] = useState([1, 2, 3]);
+  /** @sensors */
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  /**
+   *
+   * @param {*} event
+   */
+  const handleDragEnd = (event) => {
+    const { active, over } = event;
+    if (active.id !== over.id) {
+      setItems((items) => {
+        const oldIndex = items.indexOf(active.id);
+        const newIndex = items.indexOf(over.id);
+        return arrayMove(items, oldIndex, newIndex);
+      });
+    }
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+      modifiers={[restrictToVerticalAxis, restrictToWindowEdges]}
+    >
+      <SortableContext items={items} strategy={verticalListSortingStrategy}>
+        {items.map((id) => (
+          <SortableItem key={id} id={id} />
+        ))}
+      </SortableContext>
+    </DndContext>
+  );
+};
+
+export default InputRanking;

--- a/src/pages/Booth/Election/QuestionSection/Questions/SortableItem.jsx
+++ b/src/pages/Booth/Election/QuestionSection/Questions/SortableItem.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {useSortable} from '@dnd-kit/sortable';
+import {CSS} from '@dnd-kit/utilities';
+
+export function SortableItem(props) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({id: props.id});
+  
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  
+  return (
+    <div className={props.className} ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      {props.content}
+    </div>
+  );
+}

--- a/src/pages/Booth/Election/QuestionSection/RankingSelection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/RankingSelection.jsx
@@ -1,7 +1,11 @@
 import InputRanking from "./Questions/InputRanking";
+import { useState } from "react";
 
 const RankingSelection = (props) => {
-  const [answers, setAnswers] = useState([]);
+  /**
+   * answers initial state is an array with option indices.
+   */
+  const [answers, setAnswers] = useState(Array.from(props.question.closed_options.keys()));
   return (
     <div>
       <div>

--- a/src/pages/Booth/Election/QuestionSection/RankingSelection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/RankingSelection.jsx
@@ -1,0 +1,22 @@
+import InputRanking from "./Questions/InputRanking";
+
+const RankingSelection = (props) => {
+  const [answers, setAnswers] = useState([]);
+  return (
+    <div>
+      <div>
+        <InputRanking
+          index={props.index}
+          election={props.election}
+          question={props.question}
+          answers={answers}
+          setAnswers={setAnswers}
+          addAnswer={props.addAnswer}
+          value={String(props.index)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default RankingSelection;

--- a/src/static/css/booth.css
+++ b/src/static/css/booth.css
@@ -860,3 +860,47 @@ canvas {
     max-width: 50%;
   }
 }
+
+
+/* ranking election test */
+
+.ranking__container {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+}
+
+.ranking__idx_col {
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  align-content: center;
+  width: 10%;
+}
+
+.ranking__opt_col {
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  align-content: center;
+  width: 85%;
+}
+
+.ranking__idx {
+  font-size: 1.2em;
+  font-weight: 900;
+  border-radius: 2em;
+  margin: 1.35em;
+  color: white;
+}
+
+.ranking__btn {
+  padding: 1em 2em;
+  border: #84C7EF solid 2px;
+  background: white;
+  color: black;
+  font-weight: 700;
+  margin: .5em;
+  border-radius: 1em;
+  width: 100%;
+}

--- a/src/static/css/booth.css
+++ b/src/static/css/booth.css
@@ -862,7 +862,7 @@ canvas {
 }
 
 
-/* ranking election test */
+/* ranking-question-dev */
 
 .ranking__container {
   display: flex;


### PR DESCRIPTION
# Objetivo
Poder crear y visualizar una pregunta que se responda mediante ranking preferencial, en particular que implemente el algoritmo STV en un escenario sin coerción.

# Estrategia
- Modificar el formulario de creación de preguntas.
- Crear una interfaz de votación que permita ordenar las opciones según preferencia.

# Resultado
![Captura de Pantalla 2023-08-23 a la(s) 21 44 26](https://github.com/clcert/psifos-frontend/assets/53621395/b4136bd6-944a-4696-a3db-3c5d11b8a4eb)
![Captura de Pantalla 2023-08-23 a la(s) 21 45 02](https://github.com/clcert/psifos-frontend/assets/53621395/c508ad33-b79a-4aeb-a4b8-2763f8cfefb5)

# Dependencias
Para observar los resultados es necesario ubicarse en la siguiente rama del backend operativo
- https://github.com/clcert/psifos-backend-op/pull/34

# Testing
1. Crear una elección
2. Crear una pregunta con ranking preferencial que no incluya nulos y blancos y con mínimo y máximo de respuestas igual a 1
3. Guardar la pregunta y ver la previsualización

