### PR TITLE
[QA] Cabina de votación

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -42,3 +42,10 @@ export const events = {
         descript: "La lista de votantes ha sido actualizada.",
     }
 }
+
+export const permanentOptions = {
+    whiteOptionText: 'Voto Blanco',
+    nullOptionText: 'Voto Nulo'
+}
+
+export const permanentOptionsList = Object.values(permanentOptions)

--- a/src/pages/Booth/Election/QuestionSection/InputSelection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/InputSelection.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import InputCheckbox from "./Questions/InputCheckbox";
 import InputRadio from "./Questions/InputRadio";
+import { permanentOptions } from "../../../../constants";
 
 function InputSelection(props) {
   /** @state {boolean} answers text */
@@ -15,6 +16,8 @@ function InputSelection(props) {
 
   const nullValue = props.question.closed_options.length - 1;
   const blankValue = props.question.closed_options.length - 2;
+
+  const {whiteOptionText, nullOptionText} = permanentOptions
 
   function nullVote(event) {
     if (event.target.checked) {
@@ -95,7 +98,7 @@ function InputSelection(props) {
                   blankVote(event);
                 }}
               />
-              <span className="is-size-5">Voto Blanco</span>
+              <span className="is-size-5"> {whiteOptionText} </span>
             </label>
           </div>
           <div className="mt-2">
@@ -116,7 +119,7 @@ function InputSelection(props) {
                   nullVote(event);
                 }}
               />
-              <span className="is-size-5">Voto Nulo</span>
+              <span className="is-size-5"> {nullOptionText} </span>
             </label>
           </div>
         </>

--- a/src/pages/Booth/Election/QuestionSection/InputSelection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/InputSelection.jsx
@@ -80,7 +80,7 @@ function InputSelection(props) {
           <div className="mt-2">
             <label
               className={
-                "d-inline-flex align-items-center radio question-answer px-3 py-2 " +
+                "d-inline-flex align-items-center radio question-answer question-answer-enabled px-3 py-2 " +
                 (blankButton ? "answer-selected" : "")
               }
             >
@@ -101,7 +101,7 @@ function InputSelection(props) {
           <div className="mt-2">
             <label
               className={
-                "d-inline-flex align-items-center radio question-answer px-3 py-2 " +
+                "d-inline-flex align-items-center radio question-answer question-answer-enabled px-3 py-2 " +
                 (nullButton ? "answer-selected" : "")
               }
             >

--- a/src/pages/Booth/Election/QuestionSection/MixnetSelection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/MixnetSelection.jsx
@@ -272,7 +272,7 @@ function MixnetSelection(props) {
             <label
               id=""
               className={
-                "d-inline-flex align-items-center radio question-answer px-3 py-2  " +
+                "d-inline-flex align-items-center radio question-answer question-answer-enabled px-3 py-2  " +
                 (blankButton ? "answer-selected" : "")
               }
             >
@@ -293,7 +293,7 @@ function MixnetSelection(props) {
             <label
               id=""
               className={
-                "d-inline-flex align-items-center radio question-answer px-3 py-2  " +
+                "d-inline-flex align-items-center radio question-answer question-answer-enabled px-3 py-2  " +
                 (nullButton ? "answer-selected" : "")
               }
             >

--- a/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
@@ -9,6 +9,7 @@ import AlertQuestions from "./Questions/AlertQuestions";
 import MixnetSelection from "./MixnetSelection";
 import InputSelection from "./InputSelection";
 import { answersRestrictionText } from './utils.js'
+import { permanentOptionsList } from "../../../../constants";
 
 function QuestionElection(props) {
   /** Component for election questions */
@@ -59,12 +60,25 @@ function QuestionElection(props) {
        * Check if the number of answers is correct
        * If not, show the alert
        */
-      const min = props.questions[index].min_answers;
-      const max = props.questions[index].max_answers;
-      if (answers[index].length < min || answers[index].length > max) {
-        setShowAlert(true);
-        setMessageAlert("Debe " + answersRestrictionText(min, max));
-        return false;
+      const {questions} = props;
+      const currentQuestion = questions[index];
+      const checkedIndex = answers[index];
+      const numCheckedIndex = checkedIndex.length;
+      const options = currentQuestion.closed_options;
+
+      if (
+        !Boolean(
+          numCheckedIndex === 1 && permanentOptionsList.includes(options[checkedIndex[0]])
+        )
+      ) {
+        const {min_answers, max_answers} = currentQuestion;
+        if (
+          numCheckedIndex < min_answers || numCheckedIndex > max_answers
+        ) {
+          setShowAlert(true);
+          setMessageAlert("Debe " + answersRestrictionText(min_answers, max_answers));
+          return false;
+        }
       }
       setShowAlert(false);
       return true;

--- a/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import selectImg from "../../../../static/booth/svg/select-img.svg";
 import FinishButton from "../../components/Buttons/FinishButton";
 import NextButton from "../../components/Buttons/NextButton";
@@ -8,7 +8,7 @@ import ModalPercentage from "../../components/ModalPercentage";
 import AlertQuestions from "./Questions/AlertQuestions";
 import MixnetSelection from "./MixnetSelection";
 import InputSelection from "./InputSelection";
-import { useCallback } from "react";
+import { answersRestrictionText } from './utils.js'
 
 function QuestionElection(props) {
   /** Component for election questions */
@@ -52,21 +52,6 @@ function QuestionElection(props) {
     setAnswers(answersAux);
   }, [props.questions]);
 
-  function createMessageAlert(min, max) {
-    /**
-     * @param {number} min - minimum number of answers
-     * @param {number} max - maximum number of answers
-     * Set the message of the alert
-     */
-    if (min === max) {
-      setMessageAlert("Debes seleccionar " + min + " respuesta(s)");
-    } else {
-      setMessageAlert(
-        "Debes seleccionar entre " + min + " y " + max + " respuestas"
-      );
-    }
-  }
-
   const checkAnswers = useCallback(
     (index) => {
       /**
@@ -78,7 +63,7 @@ function QuestionElection(props) {
       const max = props.questions[index].max_answers;
       if (answers[index].length < min || answers[index].length > max) {
         setShowAlert(true);
-        createMessageAlert(min, max);
+        setMessageAlert("Debe " + answersRestrictionText(min, max));
         return false;
       }
       setShowAlert(false);
@@ -97,7 +82,7 @@ function QuestionElection(props) {
               display: props.actualQuestion === index ? "block" : "none",
             }}
           >
-            {showAlert ? <AlertQuestions message={messageAlert} /> : <></>}
+            {showAlert && <AlertQuestions message={messageAlert} />}
             <QuestionHeader
               actualQuestion={props.actualQuestion}
               totalQuestions={props.questions.length}
@@ -134,6 +119,7 @@ function QuestionElection(props) {
           <div className="column is-flex left-button-column">
             <PreviousButton
               action={() => {
+                setShowAlert(false);
                 props.nextQuestion(props.actualQuestion - 1);
               }}
             />
@@ -142,6 +128,7 @@ function QuestionElection(props) {
           <div className="column is-invisible is-flex left-button-column">
             <PreviousButton
               action={() => {
+                setShowAlert(false);
                 props.nextQuestion(props.actualQuestion - 1);
               }}
             />

--- a/src/pages/Booth/Election/QuestionSection/QuestionHeader.jsx
+++ b/src/pages/Booth/Election/QuestionSection/QuestionHeader.jsx
@@ -1,25 +1,9 @@
-function QuestionHeader(props) {
-  const generateText = () => {
-    const questions = props.questions;
-    let textAux = "(seleccionar ";
-    if (questions.min_answers === questions.max_answers) {
-      if (questions.min_answers === "1") {
-        textAux = textAux + "solo " + questions.min_answers + " opción)";
-      } else {
-        textAux = textAux + "solo " + questions.min_answers + " opciones)";
-      }
-    } else {
-      textAux =
-        textAux +
-        "entre " +
-        questions.min_answers +
-        " y " +
-        questions.max_answers +
-        " opciones)";
-    }
+import { answersRestrictionText } from './utils.js'
 
-    return textAux;
-  };
+function QuestionHeader(props) {
+
+  const questions = props.questions;
+  const restriction = answersRestrictionText(questions.min_answers,questions.max_answers )
 
   return (
     <div>
@@ -30,7 +14,7 @@ function QuestionHeader(props) {
           props.totalQuestions}
       </p>
       <p className="title is-4 has-text-black pt-6">{props.questions.q_text}</p>
-      <p className="subtitle is-italic">{generateText()}</p>
+      <p className="subtitle is-italic">{"(" + restriction + ")" }</p>
       {props.questions.q_description && (
         <p className="subtitle is-italic">{props.questions.q_description}</p>
       )}

--- a/src/pages/Booth/Election/QuestionSection/Questions/InputCheckbox.jsx
+++ b/src/pages/Booth/Election/QuestionSection/Questions/InputCheckbox.jsx
@@ -37,10 +37,12 @@ function InputCheckbox(props) {
           !props.question.include_blank_null ||
           index < props.question.closed_options.length - 2
         ) {
+          const isDesabled = disabledCondition(index)
           return (
-            <div key={index} className="mt-2">
+            <div key={index} className={"mt-2 "}>
               <label
                 className={
+                  (isDesabled ? "question-answer-desabled " : "question-answer-enabled ") +
                   "d-inline-flex align-items-center checkbox question-answer px-3 py-2 " +
                   (props.answers.includes(index) ? "answer-selected" : "")
                 }
@@ -54,9 +56,9 @@ function InputCheckbox(props) {
                     let ans = addAnswer(e, props.index);
                     props.addAnswer(ans, props.index);
                   }}
-                  disabled={disabledCondition(index)}
+                  disabled={isDesabled}
                 />
-                <span className="is-size-5">{key}</span>
+                <span className={"is-size-5"}> {key} </span>
               </label>
             </div>
           );

--- a/src/pages/Booth/Election/QuestionSection/Questions/InputRadio.jsx
+++ b/src/pages/Booth/Election/QuestionSection/Questions/InputRadio.jsx
@@ -20,7 +20,7 @@ function InputRadio(props) {
               <label
                 key={index}
                 className={
-                  "d-inline-flex align-items-center radio question-answer px-3 py-2 " +
+                  "d-inline-flex align-items-center radio question-answer question-answer-enabled px-3 py-2 " +
                   (props.answers.includes(index) ? "answer-selected" : "")
                 }
               >

--- a/src/pages/Booth/Election/QuestionSection/utils.js
+++ b/src/pages/Booth/Election/QuestionSection/utils.js
@@ -1,0 +1,19 @@
+export function answersRestrictionText(min_answers, max_answers) {
+    let textAux = "seleccionar ";
+    if (min_answers === max_answers) {
+      if (min_answers === "1") {
+        textAux = textAux + min_answers + " opción";
+      } else {
+        textAux = textAux + min_answers + " opciones";
+      }
+    } else {
+      textAux =
+        textAux +
+        "entre " +
+        min_answers +
+        " y " +
+        max_answers +
+        " opciones";
+    }
+    return textAux;
+}

--- a/src/pages/Booth/components/CastDone/ValidatedVote.jsx
+++ b/src/pages/Booth/components/CastDone/ValidatedVote.jsx
@@ -1,14 +1,17 @@
 import { useParams } from "react-router-dom";
 import { backendOpIP, frontIP } from "../../../../server";
 
-function OptinalStep({title, text}) {
+function OptinalStep({title, text, button}) {
   return(
-    <div>
-      <div className="mb-1" style={{fontSize:"23px"}}>
-        <i class="fa fa-check mr-3 is-color-blue" aria-hidden="true"/>
+    <div className="optional-step">
+      <div className="statement mb-1 text-align-justify">
+        <i class="fa fa-check mr-3 is-color-blue opt-title" aria-hidden="true"/>
         <span>{title}</span>
       </div>
-      <p>{text}</p>
+      <p className="text text-align-justify">{text}</p>
+      <div className="opt-button" style={{}}>
+        {button}
+      </div>
     </div>
   )
 }
@@ -30,14 +33,13 @@ function PrettyButton({
   )
 }
 
-function InfoCard({title, content, buttons}) {
+function InfoCard({title, content}) {
   return (
     <div className="box">
       <p className="subtitle is-3 is-color-blue">
         {title}
       </p>
       {content}
-      {buttons}
     </div>
   )
 }
@@ -92,10 +94,6 @@ function ValidatedVote(props) {
                 Su voto encriptado ha sido recibido exitosamente.
               </span>
             </div>
-          </div>
-        }
-        buttons={
-          <div>
             <PrettyButton
               onClick={exit}
               id="back-vote-button"
@@ -110,7 +108,7 @@ function ValidatedVote(props) {
       <InfoCard
         title="¿QUÉ PUEDO HACER AHORA?"
         content={
-          <div className="text-align-justify mb-5">
+          <div className="mb-4">
             <OptinalStep
               title="Puede descargar el certificado de su voto."
               text={
@@ -119,7 +117,17 @@ function ValidatedVote(props) {
                 "Sin embargo, el certificado no proporciona información sobre " +
                 "las preferencias emitidas en el voto."
               }
-              />
+              button={
+                <PrettyButton
+                  onClick={downloadFile}
+                  id="back-vote-button"
+                  icon={
+                    <i className="fa-solid fa-file-arrow-down"/>
+                  }
+                  text="DESCARGAR CERTIFICADO DE VOTO"
+                /> 
+              }
+            />
             <OptinalStep
               title="Puede verificar su voto en la urna electrónica."
               text={
@@ -127,39 +135,22 @@ function ValidatedVote(props) {
                 "y enviados hasta el momento. Al ingresar, podrá observar que la " +
                 "fila resaltada corresponde a una muestra de su voto encriptado."
               }
-              />
-            <OptinalStep
-              title="Si lo desea, tiene la opción de volver a votar mientras el proceso esté abierto."
-              text={
-                "En caso de hacerlo, su nuevo voto encriptado reemplazará al anterior, y solo se " +
-                "tomará en cuenta el último voto encriptado emitido."
-              }
-              />
-          </div>
-        }
-        buttons={
-          <div className="columns">
-            <div className="column castdone-box mb-0 is-5">
-              <PrettyButton
-                id="back-vote-button"
-                onClick={downloadFile}
-                text="DESCARGAR CERTIFICADO DE VOTO"
-                icon={
-                  <i className="fa-solid fa-file-arrow-down"/>
-                }
-              />  
-            </div>
-            <div className="column is-2"/>
-            <div className="column castdone-box is-5">
-              <PrettyButton
+              button={
+                <PrettyButton
                 onClick={openBallotBox}
                 id="back-vote-button"
                 icon={
                   <i className="fa-solid fa-box-archive"/>
                 }
                 text="VER URNA ELECTRÓNICA"
-              /> 
-            </div>
+              />
+              }
+              />
+              <p className="optional-note">
+                ¡Importante! Si así lo desea, tiene la opción de volver a votar mientras el proceso
+                se mantenga abierto. En caso de que decida hacerlo, su nuevo voto encriptado reemplazará
+                al anterior y solo se considerará válido el último voto encriptado emitido.
+              </p>
           </div>
         }
       />

--- a/src/pages/Booth/components/CastDone/ValidatedVote.jsx
+++ b/src/pages/Booth/components/CastDone/ValidatedVote.jsx
@@ -1,6 +1,47 @@
 import { useParams } from "react-router-dom";
 import { backendOpIP, frontIP } from "../../../../server";
 
+function OptinalStep({title, text}) {
+  return(
+    <div>
+      <div className="mb-1" style={{fontSize:"23px"}}>
+        <i class="fa fa-check mr-3 is-color-blue" aria-hidden="true"/>
+        <span>{title}</span>
+      </div>
+      <p>{text}</p>
+    </div>
+  )
+}
+
+function PrettyButton({
+  onClick, icon, text, id
+}) {
+  return (
+    <button
+      className="button"
+      onClick={onClick}
+      id={id}
+    >
+      <span className="icon is-small">
+        {icon}
+      </span>
+      <span>{text}</span>
+    </button>
+  )
+}
+
+function InfoCard({title, content, buttons}) {
+  return (
+    <div className="box">
+      <p className="subtitle is-3 is-color-blue">
+        {title}
+      </p>
+      {content}
+      {buttons}
+    </div>
+  )
+}
+
 function ValidatedVote(props) {
   const { shortName } = useParams();
   async function downloadFile() {
@@ -41,71 +82,88 @@ function ValidatedVote(props) {
   }
 
   return (
-    <>
-      <p className="subtitle is-3 has-text-black mb-1">
-        HEMOS RECIBIDO TU VOTO ENCRIPTADO
-      </p>
-      <p className="subtitle has-text-black send-text">
-        Tu voto encriptado ha sido recibido y validado exitosamente
-      </p>
-
-      <div className="columns">
-        <div className="column castdone-box mb-0 is-5">
-          <button
-            className="button"
-            onClick={downloadFile}
-            id="back-vote-button"
-          >
-            <span className="icon is-small is-size-7-touch">
-              <i className="fa-solid fa-file-arrow-down"></i>
-            </span>
-            <span className="is-size-7-touch">
-              DESCARGAR CERTIFICADO DE VOTO
-            </span>
-          </button>
-          <p className="subtitle is-6 mt-3">
-            El certificado de voto no permite conocer como votaste, sino que
-            solamente acredita que tu voto fue realizado correctamente y será
-            contabilizado en el escrutinio final.
-          </p>
-        </div>
-
-        <div className="column is-2"></div>
-
-        <div className="column castdone-box is-5">
-          <button
-            className="button"
-            onClick={openBallotBox}
-            id="back-vote-button"
-          >
-            <span className="icon is-small">
-              <i className="fa-solid fa-box-archive"></i>
-            </span>
-            <span>VER URNA ELECTRÓNICA</span>
-          </button>
-          <p className="subtitle is-6 mt-3">
-            La urna electrónica contiene todos los votos encriptados enviados hasta
-            el momento.
-          </p>
-        </div>
-      </div>
-
-      <p className="subtitle is-5 pb-2 mt-4">
-        Si lo deseas, puedes volver a votar durante el tiempo que la votación
-        esté abierta. Si lo haces, el nuevo voto encriptado reemplazará al existente, y
-        sólo se contabilizará el último voto encriptado emitido.
-      </p>
-      <button
-        onClick={exit}
-        className="button is-medium my-4"
-        id="back-vote-button"
-      >
-        <span className="icon is-small">
-          <i className="fas fa-2x fa-caret-left"></i>
-        </span>
-        <span>SALIR</span>
-      </button>
-    </>
+    <div className="validated-vote">
+      <InfoCard 
+        title="SU PROCESO DE VOTACIÓN HA FINALIZADO"
+        content={
+          <div>
+            <div className="mb-4" style={{fontSize:"23px"}}>
+              <span>
+                Su voto encriptado ha sido recibido exitosamente.
+              </span>
+            </div>
+          </div>
+        }
+        buttons={
+          <div>
+            <PrettyButton
+              onClick={exit}
+              id="back-vote-button"
+              icon={
+                <i class="fa-solid fa-house" style={{fontSize: "18px"}}/>
+              }
+              text="VOLVER AL INICIO"
+            />
+          </div>
+        }
+      />
+      <InfoCard
+        title="¿QUÉ PUEDO HACER AHORA?"
+        content={
+          <div className="text-align-justify mb-5">
+            <OptinalStep
+              title="Puede descargar el certificado de su voto."
+              text={
+                "Este documento acredita que tu voto fue realizado " +
+                "correctamente y que será contabilizado en el escrutinio final. " +
+                "Sin embargo, el certificado no proporciona información sobre " +
+                "las preferencias emitidas en el voto."
+              }
+              />
+            <OptinalStep
+              title="Puede verificar su voto en la urna electrónica."
+              text={
+                "En este lugar se encuentran todos los votos encriptados " +
+                "y enviados hasta el momento. Al ingresar, podrá observar que la " +
+                "fila resaltada corresponde a una muestra de su voto encriptado."
+              }
+              />
+            <OptinalStep
+              title="Si lo desea, tiene la opción de volver a votar mientras el proceso esté abierto."
+              text={
+                "En caso de hacerlo, su nuevo voto encriptado reemplazará al anterior, y solo se " +
+                "tomará en cuenta el último voto encriptado emitido."
+              }
+              />
+          </div>
+        }
+        buttons={
+          <div className="columns">
+            <div className="column castdone-box mb-0 is-5">
+              <PrettyButton
+                id="back-vote-button"
+                onClick={downloadFile}
+                text="DESCARGAR CERTIFICADO DE VOTO"
+                icon={
+                  <i className="fa-solid fa-file-arrow-down"/>
+                }
+              />  
+            </div>
+            <div className="column is-2"/>
+            <div className="column castdone-box is-5">
+              <PrettyButton
+                onClick={openBallotBox}
+                id="back-vote-button"
+                icon={
+                  <i className="fa-solid fa-box-archive"/>
+                }
+                text="VER URNA ELECTRÓNICA"
+              /> 
+            </div>
+          </div>
+        }
+      />
+    </div>
   );
 }
 

--- a/src/static/assets_home/css/Home.css
+++ b/src/static/assets_home/css/Home.css
@@ -13283,3 +13283,26 @@ Consult
 .text-align-justify {
   text-align: justify;
 }
+
+.optional-note {
+  font-weight: bold;
+  font-style: italic;
+  margin-top: 12px;
+}
+
+.optional-step .statement {
+  font-size: 23px;
+  justify-content: flex-start;
+}
+
+.optional-step .text {
+  margin: 1rem 0rem;
+}
+
+.optional-step .opt-button {
+  margin: 20px;
+}
+
+.optional-step .opt-title {
+  margin-top: 1rem;
+}

--- a/src/static/assets_home/css/Home.css
+++ b/src/static/assets_home/css/Home.css
@@ -13279,3 +13279,7 @@ Consult
   color: red;
   margin-left: 5px;
 }
+
+.text-align-justify {
+  text-align: justify;
+}

--- a/src/static/assets_home/css/Home.css
+++ b/src/static/assets_home/css/Home.css
@@ -844,8 +844,12 @@ input[type="radio"] {
   user-select: none;
 }
 
-.question-answer:hover {
+.question-answer-enabled:hover {
   color: #00b7ff !important;
+}
+
+.question-answer-desabled:hover {
+  color: white !important;
 }
 
 .previous-button {
@@ -916,7 +920,7 @@ input[type="radio"] {
 }
 
 .review-buttons:hover {
-  background-color: #00b7ff !important;
+  background-color: red !important;
 }
 
 .right-button-column {

--- a/src/static/booth/css/booth.css
+++ b/src/static/booth/css/booth.css
@@ -375,7 +375,7 @@ input[type=radio] {
   border-radius: 5px;
 }
 
-.question-answer:hover {
+.question-answer-enabled:hover {
   color: #00b7ff !important;
 }
 

--- a/src/static/booth/css/booth.scss
+++ b/src/static/booth/css/booth.scss
@@ -438,7 +438,7 @@ input[type="radio"] {
   border-radius: 5px;
 }
 
-.question-answer:hover {
+.question-answer-enabled:hover {
   color: #00b7ff !important;
 }
 

--- a/src/static/booth/templates/question.html
+++ b/src/static/booth/templates/question.html
@@ -34,10 +34,10 @@
                     <div id="answer_label_{$T.question_num}_{$T.answer_ordering[$T.answer$index]}">
 
                         {#if $T.question.max == 1 && $T.question.min == 1}
-                        <label id="answer_wrapper_{$T.question_num}_{$T.answer_ordering[$T.answer$index]}" class="radio question-answer p-2">
+                        <label id="answer_wrapper_{$T.question_num}_{$T.answer_ordering[$T.answer$index]}" class="radio question-answer question-answer-enabled p-2">
                             <input type="radio" id="answer_{$T.question_num}_{$T.answer_ordering[$T.answer$index]}" name="answer_{$T.question_num}" value="answer_{$T.question_num}_{$T.answer_ordering[$T.answer$index]}" onclick="BOOTH.click_radiobox({$T.question_num}, {$T.answer_ordering[$T.answer$index]}, this.checked);"/>
                         {#else}
-                            <label id="answer_wrapper_{$T.question_num}_{$T.answer_ordering[$T.answer$index]}" class="checkbox question-answer p-2">
+                            <label id="answer_wrapper_{$T.question_num}_{$T.answer_ordering[$T.answer$index]}" class="checkbox question-answer question-answer-enabled p-2">
                             <input type="checkbox" class="ballot_answer" id="answer_{$T.question_num}_{$T.answer_ordering[$T.answer$index]}" name="answer_{$T.question_num}_{$T.answer_ordering[$T.answer$index]}" value="yes" onclick="BOOTH.click_checkbox({$T.question_num}, {$T.answer_ordering[$T.answer$index]}, this.checked);" />
                          {#/if}
                                 <span class="is-size-4">{$T.question.answers[$T.answer_ordering[$T.answer$index]]}</span>


### PR DESCRIPTION
# Objetivo
Corregir detalles de interfaz y funcionalidades descompuestas en cabina de votación.
<img width="1047" alt="Captura de Pantalla 2023-05-29 a la(s) 11 44 31" src="https://github.com/clcert/psifos-frontend/assets/53621395/6dde1ffd-7bcf-4068-b3a4-dc454fe0bc18">
<img width="1042" alt="Captura de Pantalla 2023-05-29 a la(s) 11 46 14" src="https://github.com/clcert/psifos-frontend/assets/53621395/eb4ecf37-245c-4905-846e-57a7f4429589">
<img width="1040" alt="Captura de Pantalla 2023-05-29 a la(s) 11 47 04" src="https://github.com/clcert/psifos-frontend/assets/53621395/f37d3f90-f18c-4609-8dff-4ab940fde237">


# Estrategia
Se creó una elección con las siguientes características:
- Pregunta 1: 3 opciones, los votantes deben marcar mínimo 1 y máximo 3
- Pregunta 2: 3 opciones, los votantes deben marcar mínimo 1 y máximo 3
- Pregunta 3: 4 opciones, los votantes deben marcar mínimo 2 y máximo 3

# Detalle
## NO RESPONDER PRIMERA PREGUNTA
_REPRO_

- Loguearse y visualizar primera pregunta
- Seleccionar el botón que dice “siguiente”

_ESPERADO_

- Recibir un mensaje que diga “Debes seleccionar una opción”

_OBTENIDO_

- Recibir mensaje que dice “Debes seleccionar 1 respuesta(s)”

## NO RESPONDER SEGUNDA PREGUNTA
_REPRO_

- Loguearse correctamente
- Responder primera pregunta
- Llegar a la segunda pregunta
- Seleccionar “SIGUIENTE” sin haber respondido
- Aparece mensaje “Debes visualizar entre 1 y 3 respuestas”
- Seleccionar “ANTERIOR”

_ESPERADO_

- Mensaje de “Debes seleccionar entre 1 y 3 respuestas” desaparece

_OBTENIDO_

- Mensaje de “Debes seleccionar entre 1 y 3 respuestas” no desaparece

## OPCIÓN DESHABILITADA

- En una pregunta donde se pueden marcar máximo 3 opciones, la cuarta queda deshabilitada.
- En este caso, la checkbox no es clickeable, pero la palabra perro si lo es.

## VOTO NULO EN TERCERA PREGUNTA

_REPRO_

- Ingresar a la votación
- Responder a la primera y segunda pregunta
- Votar nulo en la tercera
- Apretar FINALIZAR

_ESPERADO_

- Se finaliza la elección

_BUG_

- Aparece mensaje “Debes seleccionar entre 2 y 3 respuestas”

## BOTÓN DE SALIR

Tiene flecha a la izquierda, que indica “volver atrás”, lo que es contrario a salir.

## PASO 3, ENVÍO
Interfaz debe indicar al votante que el proceso de votación ya ha finalizado y que el resto de los pasos son opcionales.
** Hay un [issue](https://github.com/clcert/psifos-frontend/issues/61) asociado a la eliminación de este paso. Sin embargo, su contenido (modificado en este PR) debe reubicarse en una nueva URL.

# Resultado
<img width="793" alt="Captura de Pantalla 2023-05-29 a la(s) 11 38 51" src="https://github.com/clcert/psifos-frontend/assets/53621395/5d27b2f6-8658-4c45-9f9f-8ee8a0b86445">
<img width="785" alt="Captura de Pantalla 2023-05-29 a la(s) 11 39 12" src="https://github.com/clcert/psifos-frontend/assets/53621395/0d63dfa1-a397-42d2-a877-2f3c48cfe0cc">
<img width="1045" alt="Captura de Pantalla 2023-05-29 a la(s) 11 42 15" src="https://github.com/clcert/psifos-frontend/assets/53621395/16af3020-91f1-48ed-9340-47070fc6f98a">
<img width="1041" alt="Captura de Pantalla 2023-05-29 a la(s) 11 42 31" src="https://github.com/clcert/psifos-frontend/assets/53621395/deda0c8f-f03e-42b4-980e-7efd226da9fb">
