### PR TITLE
delete init in navbar menu booth

### DIFF
--- a/src/component/ShortNavBar/MyNavbar.jsx
+++ b/src/component/ShortNavBar/MyNavbar.jsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-
 import ModalInfo from "./ModalInfo";
 import ModalHelp from "./ModalHelp";
 import NavbarLogo from "./NavbarLogo";
@@ -27,15 +26,16 @@ function MyNavbar(props) {
             <div className="navbar-end">
               <div className="navbar-item buttons-container pt-0">
                 <div id="navbar-buttons">
-                  <Link
-                    to={props.linkInit}
-                    style={{ textAlign: "left" }}
-                    className="menu-text-admin"
-                    id="text-button"
-                  >
-                    INICIO
-                  </Link>
-
+                  {props.linkInit && (
+                    <Link
+                      to={props.linkInit}
+                      style={{ textAlign: "left" }}
+                      className="menu-text-admin"
+                      id="text-button"
+                    >
+                      INICIO
+                    </Link>
+                  )}
                   <span
                     onClick={() => {
                       setShowInfo(true);
@@ -67,7 +67,11 @@ function MyNavbar(props) {
           </div>
         </nav>
       </div>
-      <ModalInfo show={showInfo} onHide={() => setShowInfo(false)} description={""} />
+      <ModalInfo
+        show={showInfo}
+        onHide={() => setShowInfo(false)}
+        description={""}
+      />
       <ModalHelp show={showHelp} onHide={() => setShowHelp(false)} />
     </div>
   );

--- a/src/pages/Booth/Election/CabinaElection.jsx
+++ b/src/pages/Booth/Election/CabinaElection.jsx
@@ -145,10 +145,7 @@ function CabinaElection(props) {
     <div id="content" className={phases[actualPhase].sectionClass}>
       <section className="parallax hero is-medium">
         <div className="hero-body pt-0 px-0 header-hero">
-          <MyNavbar
-            linkExit={backendOpIP + "/vote/" + shortName + "/logout"}
-            linkInit=""
-          />
+          <MyNavbar linkExit={backendOpIP + "/vote/" + shortName + "/logout"} />
           <TitlePsifos
             namePage={
               props.preview


### PR DESCRIPTION
## Titulo
Cambios menu de la cabina

## Descripción
Se elimina el inicio del menu de la cabina del votante

## Imagenes
![Captura desde 2023-05-30 00-04-14](https://github.com/clcert/psifos-frontend/assets/32551270/c68814ae-e3ef-4c51-817c-50f14b77dc13)

## Prueba
Se debe ingresar a la cabina de votación