### PR TITLE
add dialog for reload booth

### DIFF
--- a/src/pages/Booth/Election/CabinaElection.jsx
+++ b/src/pages/Booth/Election/CabinaElection.jsx
@@ -40,6 +40,18 @@ function CabinaElection(props) {
   /** @urlParam {shortName} election shortName  */
   const { shortName } = useParams();
 
+  // Cuadro de dialogo por si el usuario quiere refrescar
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      event.preventDefault();
+      event.returnValue = ""; // Necesario para que Chrome muestre un mensaje personalizado
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
+
   useEffect(() => {
     window.scrollTo({
       top: 0,


### PR DESCRIPTION
## Titulo
Dialogo reload

## Descripción
Se añade el aviso cuando el votante intenta recargar la pagina. Investigando un poco, por temas de seguridad no se puede generar algo personalizado cuando se intenta refrescar el navegador, por lo que el único camino seria utilizar el que brinda este,

## Imagen
![imagen](https://github.com/clcert/psifos-frontend/assets/32551270/6349fbe7-d356-4359-a1b3-33ca8c7fd45d)
