### PR TITLE
FIX Botones de sección resultado

### DIFF
--- a/src/pages/Booth/components/CastDone/ValidatedVote.jsx
+++ b/src/pages/Booth/components/CastDone/ValidatedVote.jsx
@@ -24,8 +24,8 @@ function PrettyButton({ onClick, icon, text, id, subContent }) {
   return (
     <div>
       <button className="button" onClick={onClick} id={id}>
-        <span className="icon is-small">{icon}</span>
-        <span className="is-size-7-mobile">{text}</span>
+        <span className="icon">{icon}</span>
+        <span className="is-size-05-mobile">{text}</span>
       </button>
       {subContent}
     </div>
@@ -121,7 +121,7 @@ function ValidatedVote(props) {
             <OptinalStep
               title="Puede descargar el certificado de su voto."
               text={
-                "Este documento acredita que tu voto fue realizado " +
+                "Este documento acredita que su voto fue realizado " +
                 "correctamente y que será contabilizado en el escrutinio final. " +
                 "Sin embargo, el certificado no proporciona información sobre " +
                 "las preferencias emitidas en el voto."

--- a/src/static/assets_home/css/Home.css
+++ b/src/static/assets_home/css/Home.css
@@ -10647,6 +10647,10 @@ a.has-text-danger-dark:focus {
   .is-size-7-mobile {
     font-size: 0.75rem !important;
   }
+
+  .is-size-05-mobile {
+    font-size: 50% !important;
+  }
 }
 @media screen and (min-width: 769px), print {
   .is-size-1-tablet {


### PR DESCRIPTION
# Objetivo
Que los botones de la sección de resultados se vean bien en todos los dispositivos.

# Resultado
<img width="261" alt="Captura de Pantalla 2023-07-05 a la(s) 17 34 42" src="https://github.com/clcert/psifos-frontend/assets/53621395/19f5b689-0ebf-4328-a82b-5cbe94db035a">
<img width="776" alt="Captura de Pantalla 2023-07-05 a la(s) 17 34 59" src="https://github.com/clcert/psifos-frontend/assets/53621395/9588746c-4cd4-4e3c-9455-744364caf0d8">
