### PR TITLE
[FIX] Mostrar tabla de comparaciones

### DIFF
--- a/src/pages/Admin/Results/components/Results.jsx
+++ b/src/pages/Admin/Results/components/Results.jsx
@@ -128,9 +128,11 @@ function CalculatedResults({ questions, results, election }) {
       <div className="box ">
         <ResumenElection />
       </div>
-      <div className="box ">
-        <WeightsTableSection />
-      </div>
+      {election.max_weight !== 1 && (
+        <div className="box ">
+          <WeightsTableSection />
+        </div>
+      )}
       <div className="box ">
         <ResultsPerQuestion
           election={election}


### PR DESCRIPTION
# Objetivo
En el portal de información, pestaña de resultados, se debe mostrar la tabla de ponderaciones cuando sea pertinente.

# Estrategia
Mostrar la tabla solo cuando el máximo peso de la elección es mayor a 1

# Resultado
<img width="1361" alt="Captura de Pantalla 2023-07-05 a la(s) 18 27 51" src="https://github.com/clcert/psifos-frontend/assets/53621395/482e6b5d-6d24-46b2-b72f-57ff9a9b1184">
<img width="1023" alt="Captura de Pantalla 2023-07-05 a la(s) 18 28 45" src="https://github.com/clcert/psifos-frontend/assets/53621395/652e5855-c7ae-46b4-aad3-a0701d9fe0b5">




