### PR TITLE
FIX Nro min y max de respuestas

### DIFF
--- a/src/pages/Admin/CreateQuestion.js/component/OptionQuestions.jsx
+++ b/src/pages/Admin/CreateQuestion.js/component/OptionQuestions.jsx
@@ -129,6 +129,10 @@ function OptionQuestions(props) {
     props.question.closed_options,
   ]);
 
+  useEffect(() => {
+    props.disabledMinAns && setMinAnswers(1)
+  }, [props.disabledMinAns]);
+
   return (
     <div>
       <div className="field">
@@ -156,13 +160,16 @@ function OptionQuestions(props) {
             <label className="label">Cantidad minima respuestas</label>
             <div className="control">
               <input
-                disabled={props.disabledEdit}
+                disabled={props.disabledEdit || props.disabledMinAns}
                 value={minAnswers}
                 className={"input " + (checkMinAnswers ? "" : "is-danger")}
                 type="number"
                 placeholder="Minimo"
                 onChange={(e) => {
-                  setMinAnswers(parseInt(e.target.value));
+                  const enteredValue = parseInt(e.target.value);
+                  if (isNaN(enteredValue) || enteredValue >= 0) {
+                    setMinAnswers(enteredValue);
+                  }
                 }}
               />
             </div>
@@ -183,7 +190,10 @@ function OptionQuestions(props) {
                 type="number"
                 placeholder="Maximo"
                 onChange={(e) => {
-                  setMaxAnswers(parseInt(e.target.value));
+                  const enteredValue = parseInt(e.target.value);
+                  if (isNaN(enteredValue) || enteredValue >= 0) {
+                    setMaxAnswers(parseInt(enteredValue));
+                  }
                 }}
               />
             </div>

--- a/src/pages/Admin/CreateQuestion.js/component/OptionQuestions.jsx
+++ b/src/pages/Admin/CreateQuestion.js/component/OptionQuestions.jsx
@@ -96,7 +96,7 @@ function OptionQuestions(props) {
       maxAnswers < minAnswers
     ) {
       setTextMaxAnswers(
-        "Debe introducir un número mayor que 0 y menor que el minimo"
+        "Debe introducir un número mayor que 0 y menor que el mínimo"
       );
       setCheckMaxAnswers(false);
       final_state = false;
@@ -157,14 +157,14 @@ function OptionQuestions(props) {
       <div className="columns">
         <div className="column">
           <div className="field">
-            <label className="label">Cantidad minima respuestas</label>
+            <label className="label">Cantidad mínima de respuestas</label>
             <div className="control">
               <input
                 disabled={props.disabledEdit || props.disabledMinAns}
                 value={minAnswers}
                 className={"input " + (checkMinAnswers ? "" : "is-danger")}
                 type="number"
-                placeholder="Minimo"
+                placeholder="Mínimo"
                 onChange={(e) => {
                   const enteredValue = parseInt(e.target.value);
                   if (isNaN(enteredValue) || enteredValue >= 0) {
@@ -180,7 +180,7 @@ function OptionQuestions(props) {
         </div>
         <div className="column">
           <div className="field">
-            <label className="label">Cantidad maximas respuestas</label>
+            <label className="label">Cantidad máxima de respuestas</label>
             <div className="control">
               <input
                 id={`question-${props.questionId}-max-answers`}
@@ -188,7 +188,7 @@ function OptionQuestions(props) {
                 value={maxAnswers}
                 className={"input " + (checkMaxAnswers ? "" : "is-danger")}
                 type="number"
-                placeholder="Maximo"
+                placeholder="Máximo"
                 onChange={(e) => {
                   const enteredValue = parseInt(e.target.value);
                   if (isNaN(enteredValue) || enteredValue >= 0) {
@@ -229,7 +229,7 @@ function OptionQuestions(props) {
           </div>
           <div className="column">
             <div className="field">
-              <label className="label">Tamaño maximo respuesta abierta</label>
+              <label className="label">Tamaño máximo respuesta abierta</label>
               <div className="control">
                 <input
                   disabled={props.disabledEdit}

--- a/src/pages/Admin/CreateQuestion.js/component/QuestionsForms.jsx
+++ b/src/pages/Admin/CreateQuestion.js/component/QuestionsForms.jsx
@@ -11,6 +11,9 @@ function QuestionsForms(props) {
   /** @state {string} question type */
   const [typeQuestion, setTypeQuestion] = useState("unic");
 
+  /** @state {boolean} the question includes white & null options */
+  const [includedWhiteNull, setIncludeWhiteNull] = useState(true);
+
   useEffect(() => {
     if (props.question !== undefined) {
       let answersAux = [];
@@ -155,6 +158,7 @@ function QuestionsForms(props) {
                     let auxQuestion = props.question;
                     auxQuestion.include_blank_null = e.target.checked;
                     props.updateQuestions(props.questionId, auxQuestion);
+                    setIncludeWhiteNull(!includedWhiteNull)
                   }}
                   checked={props.question.include_blank_null}
                   type="checkbox"
@@ -198,6 +202,7 @@ function QuestionsForms(props) {
         disabledEdit={props.disabledEdit}
         checkOptions={props.checkOptions}
         updateQuestions={props.updateQuestions}
+        disabledMinAns={includedWhiteNull}
       />
 
       <div>

--- a/src/pages/Admin/CreateQuestion.js/component/QuestionsForms.jsx
+++ b/src/pages/Admin/CreateQuestion.js/component/QuestionsForms.jsx
@@ -164,11 +164,11 @@ function QuestionsForms(props) {
                   type="checkbox"
                   className="mr-2"
                 />
-                Incluir voto nulo o blanco
+                Incluir voto nulo y blanco
               </label>
             </div>
             <p className="help">
-              Se incluira la opción para votar nulo o blanco.
+              Se podrá votar por las opciones nulo y blanco.
             </p>
           </div>
           {props.question.q_type === "mixnet_question" && (

--- a/src/pages/Admin/CreateQuestion.js/component/QuestionsForms.jsx
+++ b/src/pages/Admin/CreateQuestion.js/component/QuestionsForms.jsx
@@ -12,7 +12,7 @@ function QuestionsForms(props) {
   const [typeQuestion, setTypeQuestion] = useState("unic");
 
   /** @state {boolean} the question includes white & null options */
-  const [includedWhiteNull, setIncludeWhiteNull] = useState(true);
+  const [includedWhiteNull, setIncludeWhiteNull] = useState(props.question.include_blank_null);
 
   useEffect(() => {
     if (props.question !== undefined) {


### PR DESCRIPTION
# Objetivo
Abarcar el siguiente BUG
## REPRO
Crear pregunta y marcar casilla "Incluir voto nulo o blanco"

## ESPERADO
Cantidad mínima respuestas debiera fijarse en "1".

## BUG
Cantidad mínima respuestas está libre, por lo que si se marcan "2", luego es imposible (matemáticamente por el momento) marcar la opción Nulo o Blanco

# Estrategia
Cuando la casilla está marcada, setear la cantidad mínima en 1 y deshabilitar su edición.
No permitir que se ingresen valores menores a 0 en los input de cantidad de respuesta.
Corregir ortografía del formulario.

# Resultado
<img width="671" alt="Captura de Pantalla 2023-07-14 a la(s) 12 52 09" src="https://github.com/clcert/psifos-frontend/assets/53621395/b948ad89-cfb6-40e5-825a-5b9604cd3785">
<img width="686" alt="Captura de Pantalla 2023-07-14 a la(s) 12 52 26" src="https://github.com/clcert/psifos-frontend/assets/53621395/12f204a3-89f0-4832-8552-df24af1e597d">
