### PR TITLE
fix search mixnet

### DIFF
--- a/src/pages/Booth/Election/QuestionSection/MixnetSelection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/MixnetSelection.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useCallback } from "react";
 import { useEffect } from "react";
 import AsyncSelect from "react-select/async";
+import { normalizedLowerCase } from "../../../../utils/utils";
 
 function MixnetSelection({ question, addAnswer, numQuestion }) {
   const defaultPlaceHolder = "Seleccione o escriba una opción 🔎";
@@ -98,22 +99,25 @@ function MixnetSelection({ question, addAnswer, numQuestion }) {
 
   const filterOptions = useCallback(
     (inputValue) => {
+      const inputNormalized = normalizedLowerCase(inputValue);
       if (!isMixnetGroup) {
-        return options.filter((i) =>
-          i.label
-            .toLowerCase()
-            .normalize("NFD")
-            .includes(inputValue.toLowerCase().normalize("NFD"))
-        );
+        return options.filter((option) => {
+          const optionNormalized = normalizedLowerCase(option.label);
+          return (
+            inputNormalized.includes(optionNormalized) ||
+            optionNormalized.includes(inputNormalized)
+          );
+        });
       }
       const auxOptions = JSON.parse(JSON.stringify(options));
       auxOptions.forEach((option) => {
-        option.options = option.options.filter((i) =>
-          i.label
-            .toLowerCase()
-            .normalize("NFD")
-            .includes(inputValue.toLowerCase().normalize("NFD"))
-        );
+        option.options = option.options.filter((optionGroup) => {
+          const optionNormalized = normalizedLowerCase(optionGroup.label);
+          return (
+            inputNormalized.includes(optionNormalized) ||
+            optionNormalized.includes(inputNormalized)
+          );
+        });
       });
       return auxOptions;
     },
@@ -190,7 +194,7 @@ function MixnetSelection({ question, addAnswer, numQuestion }) {
       isMixnetGroup,
       changeAllEncrypted,
       question,
-      numQuestion
+      numQuestion,
     ]
   );
 


### PR DESCRIPTION
## Titulo
Corrección de buscar mixnet

## Descripción 
Se agrega una normalización de acentos para el buscador de mixnet

## Imagenes
![imagen](https://github.com/clcert/psifos-frontend/assets/32551270/f0e2ec45-56d2-453a-b51a-15ba01b73696)
