### PR TITLE
FEATURE forbid verification on mixnet elections

### DIFF
--- a/src/pages/Admin/ElectionResume/components/ResumeTable.jsx
+++ b/src/pages/Admin/ElectionResume/components/ResumeTable.jsx
@@ -27,7 +27,7 @@ export default function ResumeTable() {
       <table
         id="resume-table"
         className="mt-2 table is-bordered is-hoverable voters-table"
-        style={{maxWidth: "50%"}}
+        style={{maxWidth: "350px"}}
       >
         <tbody>
           <tr>

--- a/src/pages/Admin/Results/ResultsPerQuestion.jsx
+++ b/src/pages/Admin/Results/ResultsPerQuestion.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import PsifosTable from "./components/PsifosTable";
 import CardTitle from "./components/CardTitle";
+import { getResponseWithoutGroup } from "../utils";
 
 function PercentageOptions({ handleChange, currentValue }) {
     return (
@@ -65,8 +66,16 @@ function BoxPerQuestion({
 
     const resultByOption = result.reduce((accumulator, currentValue) => {
         const {
-            PorcentajeSobreVotosValidos, PorcentajeSobreVotosEmitidos, ...infoGeneral
+            PorcentajeSobreVotosValidos, PorcentajeSobreVotosEmitidos, Respuesta, Votos,
         } = currentValue
+
+        const infoGeneral = {
+            'Respuesta': question.q_type === "mixnet_question"
+            ? getResponseWithoutGroup(Respuesta)
+            : Respuesta,
+            Votos,
+        }
+
         if (percentageOption === 'votosValidos') {
             accumulator.push({...infoGeneral, Porcentaje: PorcentajeSobreVotosValidos})
         }

--- a/src/pages/Admin/utils.jsx
+++ b/src/pages/Admin/utils.jsx
@@ -6,3 +6,11 @@ export const getPercentage = (frec, total) => {
   }
   return dec.toString() + "%";
 };
+
+export const getResponseWithoutGroup = (response) => {
+  const responseArr = response.split(',')
+  if (responseArr.length > 1) {
+    return responseArr[0]
+  }
+  return response
+}

--- a/src/pages/Booth/Election/Review/TextSelected.jsx
+++ b/src/pages/Booth/Election/Review/TextSelected.jsx
@@ -36,7 +36,7 @@ function TextSelected({ answers, index, question }) {
                   {"[ ✓ ] " +
                     (question.q_type === "mixnet_question"
                       ? answer.split(",").length > 1
-                        ? answer.split(",")[0] + " - " + answer.split(",")[1]
+                        ? answer.split(",")[0]
                         : answer
                       : answer)}
                 </span>

--- a/src/pages/Booth/Panel/InfoBoothView.jsx
+++ b/src/pages/Booth/Panel/InfoBoothView.jsx
@@ -54,7 +54,9 @@ function InfoBoothView() {
         {activeNumber === 1 && <StatisticsBooth />}
         {activeNumber === 2 && <LoggerBoth />}
         {activeNumber === 3 && <Results />}
-        {activeNumber === 4 && <VerifyElection />}
+        {activeNumber === 4 && <VerifyElection
+          includesMnQuestion={election.questions.includes("mixnet_question")}
+        />}
       </section>
 
       <FooterParticipa message="Participa UChile es un proyecto de CLCERT - Universidad de Chile" />

--- a/src/pages/Booth/Panel/VerifyElection.jsx
+++ b/src/pages/Booth/Panel/VerifyElection.jsx
@@ -23,7 +23,7 @@ function EnabledVerification() {
   );
 }
 
-function VerifyElection() {
+function VerifyElection({ includesMnQuestion }) {
   const [status, setStatus] = useState("");
 
   /** @urlParam {string} shortName of election */
@@ -45,7 +45,15 @@ function VerifyElection() {
         <EnabledVerification />
       ) : (
         <NotAvalaibleMessage
-          message="Elección no finalizada"
+          message={
+            includesMnQuestion
+            ? "¡En desarrollo!"
+            : "Elección no finalizada"
+          }
+          note={
+            includesMnQuestion
+            && "Esta elección calcula sus resultados utilizando Mix Network, por lo que no es posible realizar el proceso de verificación por el momento. Estamos trabajando para permitir el proceso de verificación en este tipo de elecciones a la brevedad."
+          }
         />
       )}
     </div>

--- a/src/pages/Booth/components/NotAvalaibleMessage.jsx
+++ b/src/pages/Booth/components/NotAvalaibleMessage.jsx
@@ -1,9 +1,16 @@
-export default function NotAvalaibleMessage({message}) {
+export default function NotAvalaibleMessage({message, note}) {
     return (
-        <div className="box has-text-centered" id="not-results-box">
+        <div
+            className="box has-text-centered"
+            id="not-results-box"
+            style={{ maxWidth: "700px" }}
+        >
             <p className="is-size-3 has-text-weight-bold mb-0">
             {message}
             </p>
+            {note && <p className="is-size-8 has-text-weight-bold mb-0">
+                {note}
+            </p>}
         </div>
     )
 }

--- a/src/static/assets_home/css/Home.css
+++ b/src/static/assets_home/css/Home.css
@@ -7780,6 +7780,8 @@ label.panel-block:hover {
   flex-grow: 1;
   flex-shrink: 1;
   padding: 0.75rem;
+  margin-left: 10px;
+  margin-right: 10px;
 }
 .columns.is-mobile > .column.is-narrow {
   flex: none;


### PR DESCRIPTION
# Objetivo
Revisar correcto funcionamiento en elecciones que contienen solo una pregunta, siendo esta con mixnet.

# Estrategia
## Verificación
Las elecciones que contienen preguntas con mixnet no pueden ser verificadas, pues aun no se cuenta con las herramientas para llevar a cabo el proceso. Por eso, en la pestaña de verificación debe aparecer un mensaje que de cuenta de la situación.

## Resultados
En las tablas de resultados, el nombre de los candidatos NO debe mostrar el grupo asociado. Además, las tablas deben tener un ancho que permita leer la información claramente.

# Testing
- Crear una elección que contenga una única pregunta y que calcule su resultado con Mix Network.
- Votar y dirigirse al panel de información

# Resultado
## Verificación
<img width="1215" alt="Captura de Pantalla 2023-07-24 a la(s) 14 54 58" src="https://github.com/clcert/psifos-frontend/assets/53621395/0872211a-5a36-4e5b-8211-99c455937c37">

## Resultados
<img width="1428" alt="Captura de Pantalla 2023-07-24 a la(s) 18 30 28" src="https://github.com/clcert/psifos-frontend/assets/53621395/83912d54-a947-48ef-b389-967f2a1986e2">
<img width="1348" alt="Captura de Pantalla 2023-07-26 a la(s) 10 27 18" src="https://github.com/clcert/psifos-frontend/assets/53621395/3d904c84-aed8-44c3-9701-6e622a138e1c">


## Cabina Votación
<img width="744" alt="Captura de Pantalla 2023-07-26 a la(s) 10 11 06" src="https://github.com/clcert/psifos-frontend/assets/53621395/5f88ccc8-6953-4140-a509-8103b3f81cd4">

<img width="736" alt="Captura de Pantalla 2023-07-26 a la(s) 10 11 44" src="https://github.com/clcert/psifos-frontend/assets/53621395/79bebaea-c2a0-4479-bdc0-448485352fda">

