### PR TITLE
FIX Verificación elección con mixnet

### DIFF
--- a/src/pages/Booth/Panel/VerifyElection.jsx
+++ b/src/pages/Booth/Panel/VerifyElection.jsx
@@ -41,20 +41,19 @@ function VerifyElection({ includesMnQuestion }) {
     status === electionStatus.decryptionsCombined;
   return (
     <div>
-      {finishedElection ? (
-        <EnabledVerification />
-      ) : (
+      {includesMnQuestion ? (
         <NotAvalaibleMessage
-          message={
-            includesMnQuestion
-            ? "¡En desarrollo!"
-            : "Elección no finalizada"
-          }
-          note={
-            includesMnQuestion
-            && "Esta elección calcula sus resultados utilizando Mix Network, por lo que no es posible realizar el proceso de verificación por el momento. Estamos trabajando para permitir el proceso de verificación en este tipo de elecciones a la brevedad."
-          }
+          message="¡En desarrollo!"
+          note="Esta elección calcula sus resultados utilizando Mix Network, por lo que no es posible realizar el proceso de verificación por el momento. Estamos trabajando para permitir el proceso de verificación en este tipo de elecciones a la brevedad."
         />
+      ) : (
+        finishedElection ? (
+          <EnabledVerification />
+        ) : (
+          <NotAvalaibleMessage
+            message="Elección no finalizada"
+          />
+        )
       )}
     </div>
   );


### PR DESCRIPTION
# Objetivo
Las elecciones que utilizan mixnet siempre deben mostrar mensaje de verificación "En progreso"

# Estrategia
Seguir las siguientes condiciones:
- Si es una elección con mn (abierta o cerrada): Mostrar mensaje "en progreso"
- Si no es una elección con mn:
   - Si es una elección abierta: Mostrar mensaje "elección no cerrada"
   - Sino: Mostrar pasos verificación 

# Resultado
![Captura de Pantalla 2023-07-27 a la(s) 11 46 19](https://github.com/clcert/psifos-frontend/assets/53621395/889c5e76-e9f8-4f40-92f1-9e9fd35117e2)
