### PR TITLE
FIX Desencriptación parcial en Safari

### DIFF
--- a/src/pages/Admin/CustodioClaves/DecryptProve.jsx
+++ b/src/pages/Admin/CustodioClaves/DecryptProve.jsx
@@ -28,7 +28,8 @@ function DecryptProve() {
   let WORKERS = [];
   let RESULT_WORKERS = [];
   let WORKERS_QUESTIONS = [];
-  const TOTAL_WORKERS = Math.max(navigator.hardwareConcurrency, 4);
+  const TOTAL_WORKERS = navigator.hardwareConcurrency ?
+  Math.max(navigator.hardwareConcurrency, 4) : 1;
   let QUESTIONS_COMPLETE = 0;
   let TOTAL_TALLY;
 


### PR DESCRIPTION
# Issue
## Repro
Crear una elección con tres custodios y que uno de ellos realice sus procesos en Safari.

## Esperado
La desencriptación parcial se realiza exitosamente desde Safari.

## Bug
La desencriptación parcial no finaliza.

# Solución
Safari no era capaz de identificar los núcleos disponibles para realizar la desencriptación, por lo que se quedaba pegado en un NaN.
Por default, si no se logra identificar la cantidad se asume que es 1.