### PR TITLE
FEAT Ocultar clave privada

### DIFF
--- a/src/pages/Admin/CustodioClaves/CheckSk.jsx
+++ b/src/pages/Admin/CustodioClaves/CheckSk.jsx
@@ -83,13 +83,6 @@ function CheckSk(props) {
         <div className="container has-text-centered is-max-desktop">
           <h4 className="has-text-white">Inserte su clave privada aquí</h4>
           <DropFile setText={check_sk} />
-          <input
-            type="text"
-            disabled
-            className="input mb-3 mt-4 is-family-monospace has-text-centered"
-            placeholder="Clave privada..."
-            value={secretKey}
-          />
           <p id="feedback-check" className="has-text-white is-size-4">{feedbackMessage}</p>
           <div className="d-flex justify-content-center flex-sm-row flex-column-reverse mt-4">
             <button id="button-init" className="button is-link mx-sm-2 mt-2">

--- a/src/pages/Admin/CustodioClaves/DecryptProve.jsx
+++ b/src/pages/Admin/CustodioClaves/DecryptProve.jsx
@@ -219,12 +219,6 @@ function DecryptProve() {
           <div id="sk_section">
             <h3>Inserte su clave privada aquí</h3>
             <DropFile setText={decrypt} />
-            <input
-              value={secretKey}
-              className="input mb-2 mt-4 has-text-centered is-family-monospace"
-              placeholder="Clave privada..."
-              disabled
-            />
             <p
               id={`feedback-message-${actualStep}`}
               className="has-text-white pt-2"


### PR DESCRIPTION
# Objetivo
Que un custodio pueda compartir pantalla, estando en el portal de custodios, y en ningún momento se pueda ver su clave privada por la transmisión.

# Estrategia
Eliminar de las interfaces del portal de custodios lo segmentos que muestra la clave privada.
Esto ocurre:
- En la verificación de clave
- En la generación de la desencriptación parcial

# Resultado
<img width="1090" alt="Captura de Pantalla 2023-09-07 a la(s) 19 25 49" src="https://github.com/clcert/psifos-frontend/assets/53621395/86290f13-ce10-4e4a-bcb6-11ffba7fae53">
<img width="1024" alt="Captura de Pantalla 2023-09-07 a la(s) 19 26 10" src="https://github.com/clcert/psifos-frontend/assets/53621395/d4f016e2-89c3-4c79-95a9-88dc54f4335e">
