### PR TITLE
FIX No se puede votar desde preview de preguntas

### DIFF
--- a/src/pages/Booth/Election/CabinaElection.jsx
+++ b/src/pages/Booth/Election/CabinaElection.jsx
@@ -34,6 +34,7 @@ function SelectionPhase(props) {
             encrypQuestions={(answersQuestions) => {
               props.BOOTH_PSIFOS.sendEncryp(answersQuestions);
             }}
+            isPreview={props.isPreview}
           />
         </div>
       </section>
@@ -124,6 +125,7 @@ function CabinaElection(props) {
         setActualQuestion={setActualQuestion}
         actualQuestion={actualQuestion}
         BOOTH_PSIFOS={BOOTH_PSIFOS}
+        isPreview={props.preview}
       />,
     },
     2: {

--- a/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
+++ b/src/pages/Booth/Election/QuestionSection/QuestionElection.jsx
@@ -99,6 +99,7 @@ function SelectFigureBox() {
 function ContinueButtonBox({
   isNextButtonBool, answers,
   nextButtonHandler, finishButtonHandler,
+  isPreview,
 }) {
   return (
     <div className="column is-flex right-button-column">
@@ -108,7 +109,7 @@ function ContinueButtonBox({
         />
       ) : (
         <FinishButton
-          action={finishButtonHandler}
+          action={() => !isPreview && finishButtonHandler()}
           answers={answers}
         />
       )}
@@ -229,6 +230,7 @@ function QuestionElection(props) {
               setFinished(true);
             }
           }}
+          isPreview={props.isPreview}
         />
       </div>
 


### PR DESCRIPTION
# Repro
Crear una elección
Crear una o más preguntas
Ir a la previsualización de las preguntas
Llegar a la última pregunta y seleccionar el botón de finalizar

# Esperado
El botón está deshabilitado

# Bug
Aparece el siguiente error
```
ERROR
Cannot set properties of undefined (setting 'answers')
TypeError: Cannot set properties of undefined (setting 'answers')
    at BoothPsifos.sendEncryp (http://localhost:3000/static/js/bundle.js:23840:78)
    at Object.encrypQuestions (http://localhost:3000/static/js/bundle.js:24953:32)
    at Object.finishButtonHandler [as action] (http://localhost:3000/static/js/bundle.js:26160:19)
    at onClick (http://localhost:3000/static/js/bundle.js:30287:13)
    at HTMLUnknownElement.callCallback (http://localhost:3000/static/js/bundle.js:110679:18)
    at Object.invokeGuardedCallbackDev (http://localhost:3000/static/js/bundle.js:110723:20)
    at invokeGuardedCallback (http://localhost:3000/static/js/bundle.js:110778:35)
    at invokeGuardedCallbackAndCatchFirstError (http://localhost:3000/static/js/bundle.js:110792:29)
    at executeDispatch (http://localhost:3000/static/js/bundle.js:114414:7)
    at processDispatchQueueItemsInOrder (http://localhost:3000/static/js/bundle.js:114440:11)
```
Esto se produce porque el proceso de preview no cuenta con la llave pública para encriptar.