### PR TITLE
FEAT Mostrar resultados de preguntas con ranking

### DIFF
--- a/src/pages/Admin/Results/Results.jsx
+++ b/src/pages/Admin/Results/Results.jsx
@@ -3,41 +3,10 @@ import { useEffect } from "react";
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { getElectionPublic } from "../../../services/election";
-import { getPercentage } from "../utils";
 import NotAvalaibleMessage from "../../Booth/components/NotAvalaibleMessage";
-import { electionStatus, permanentOptionsList } from "../../../constants";
+import { electionStatus } from "../../../constants";
 import CalculatedResults from "./CalculatedResults";
-
-const analizeQuestionResult = (question, votesPerAns, includeWhiteNull) => {
-  const noNullWhiteAns =
-    includeWhiteNull === "True" ? votesPerAns.slice(0, -2) : votesPerAns;
-  const nValidVotes = votesPerAns.reduce((n, a) => n + parseInt(a), 0);
-  const nCastVotes = noNullWhiteAns.reduce((n, a) => n + parseInt(a), 0);
-
-  let result = [];
-  question.closed_options.forEach((answer, index) => {
-    const obj = {
-      Respuesta: answer,
-      Votos: parseInt(votesPerAns[index]),
-      PorcentajeSobreVotosValidos: getPercentage(
-        votesPerAns[index],
-        nValidVotes
-      ),
-    };
-    if (permanentOptionsList.includes(answer)) {
-      result.push(obj);
-    } else {
-      result.push({
-        ...obj,
-        PorcentajeSobreVotosEmitidos: getPercentage(
-          votesPerAns[index],
-          nCastVotes
-        ),
-      });
-    }
-  });
-  return result;
-};
+import { parseResult } from "./parseResult";
 
 function NoCalculatedResults({ getElectionResult }) {
   return (
@@ -71,7 +40,7 @@ function Results() {
     let result = [];
     questionsObject.forEach((element, q_num) => {
       result.push(
-        analizeQuestionResult(
+        parseResult(
           element,
           resultObject[q_num].ans_results,
           questionsObject[q_num].include_blank_null

--- a/src/pages/Admin/Results/ResultsPerQuestion.jsx
+++ b/src/pages/Admin/Results/ResultsPerQuestion.jsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import PsifosTable from "./components/PsifosTable";
 import CardTitle from "./components/CardTitle";
-import { getResponseWithoutGroup } from "../utils";
+import {
+    isAClosedTally, isARankingTally,
+} from "../utils";
+import { updateResult } from "./parseResult";
 
 function PercentageOptions({ handleChange, currentValue }) {
     return (
@@ -37,7 +40,7 @@ function QuestionTitle({ index, text }){
     )
 }
     
-function QuestionTables({ result, question, election }) {
+function ClosedQuestionTables({ result, question, election }) {
     return (
         <div className="disable-text-selection justify-content-md-center columns question-columns">
             <div className="column justify-content-center">
@@ -59,35 +62,33 @@ function QuestionTables({ result, question, election }) {
     )
 }
 
+function RankingQuestionTables({ result, question, election }) {
+    return (
+        <>{result}</>
+    )
+}
+
+function QuestionTables(props) {
+    return (
+        isARankingTally(props.question.tally_type)
+        ? (
+            <RankingQuestionTables
+                {...props}
+            />
+        )
+        : (isAClosedTally(props.question.tally_type) &&
+            <ClosedQuestionTables
+                {...props}
+            />
+        )
+    )
+}
+
 function BoxPerQuestion({
     question, index, election, result, 
 }) {
-    const [percentageOption, setPercentageOpcion] = useState('votosValidos')
-
-    const resultByOption = result.reduce((accumulator, currentValue) => {
-        const {
-            PorcentajeSobreVotosValidos, PorcentajeSobreVotosEmitidos, Respuesta, Votos,
-        } = currentValue
-
-        const infoGeneral = {
-            'Respuesta': question.q_type === "mixnet_question"
-            ? getResponseWithoutGroup(Respuesta)
-            : Respuesta,
-            Votos,
-        }
-
-        if (percentageOption === 'votosValidos') {
-            accumulator.push({...infoGeneral, Porcentaje: PorcentajeSobreVotosValidos})
-        }
-        else if (percentageOption === 'votosEmitidos' && PorcentajeSobreVotosEmitidos) {
-            accumulator.push({...infoGeneral, Porcentaje: PorcentajeSobreVotosEmitidos})
-        }
-        else {
-            accumulator.push(infoGeneral)
-        }
-        return accumulator
-    }, [])
-
+    const [percentageOption, setPercentageOption] = useState('votosValidos')
+    const resultByOption = updateResult(result, question, percentageOption)
     return (
         <div
             className="box question-box-results"
@@ -100,7 +101,7 @@ function BoxPerQuestion({
                 question={question}
             />
             {question.include_blank_null === "True" && <PercentageOptions
-                handleChange={(e) => setPercentageOpcion(e.target.value)}
+                handleChange={(e) => setPercentageOption(e.target.value)}
                 currentValue={percentageOption}
             />}
         </div>

--- a/src/pages/Admin/Results/ResultsPerQuestion.jsx
+++ b/src/pages/Admin/Results/ResultsPerQuestion.jsx
@@ -64,7 +64,17 @@ function ClosedQuestionTables({ result, question, election }) {
 
 function RankingQuestionTables({ result, question, election }) {
     return (
-        <>{result}</>
+        <div
+            style={{marginTop: "1rem", display: "flex"}}
+            className="is-size-6"
+        >
+            <div style={{
+                marginRight: "5px", maxWidth: "50%", wordBreak: "break-all",
+            }}>
+                {"Seleccionada(o): "}
+            </div>
+            <div> {result} </div>
+        </div>
     )
 }
 

--- a/src/pages/Admin/Results/parseResult.js
+++ b/src/pages/Admin/Results/parseResult.js
@@ -1,0 +1,84 @@
+import {
+    getResponseWithoutGroup,
+    getPercentage,
+    isARankingTally,
+    isAClosedTally,
+} from "../utils";
+import { permanentOptionsList } from "../../../constants";
+
+const parseClosedResult = (question, votesPerAns, includeWhiteNull) => {
+    const noNullWhiteAns =
+        includeWhiteNull === "True" ? votesPerAns.slice(0, -2) : votesPerAns;
+    const nValidVotes = votesPerAns.reduce((n, a) => n + parseInt(a), 0);
+    const nCastVotes = noNullWhiteAns.reduce((n, a) => n + parseInt(a), 0);
+
+    let result = [];
+    question.closed_options.forEach((answer, index) => {
+        const obj = {
+        Respuesta: answer,
+        Votos: parseInt(votesPerAns[index]),
+        PorcentajeSobreVotosValidos: getPercentage(
+            votesPerAns[index],
+            nValidVotes
+        ),
+        };
+        if (permanentOptionsList.includes(answer)) {
+        result.push(obj);
+        } else {
+        result.push({
+            ...obj,
+            PorcentajeSobreVotosEmitidos: getPercentage(
+            votesPerAns[index],
+            nCastVotes
+            ),
+        });
+        }
+    });
+    return result;
+};
+
+const parseRankingResult = (question, result) => {
+    const index = parseInt(result[0])
+    return question.closed_options[index]
+};
+
+export const parseResult = (question, result, includeWhiteNull) => {
+    return isAClosedTally(question.tally_type)
+    ? parseClosedResult(question, result, includeWhiteNull)
+    : (
+        isARankingTally(question.tally_type) 
+        && parseRankingResult(question, result)
+    )
+};
+
+const updateClosedResult = (result, question, percentageConfig) => {
+    return result.reduce((accumulator, currentValue) => {
+        const {
+            PorcentajeSobreVotosValidos, PorcentajeSobreVotosEmitidos, Respuesta, Votos,
+        } = currentValue
+
+        const infoGeneral = {
+            'Respuesta': question.q_type === "mixnet_question"
+            ? getResponseWithoutGroup(Respuesta)
+            : Respuesta,
+            Votos,
+        }
+
+        if (percentageConfig === 'votosValidos') {
+            accumulator.push({...infoGeneral, Porcentaje: PorcentajeSobreVotosValidos})
+        }
+        else if (percentageConfig === 'votosEmitidos' && PorcentajeSobreVotosEmitidos) {
+            accumulator.push({...infoGeneral, Porcentaje: PorcentajeSobreVotosEmitidos})
+        }
+        else {
+            accumulator.push(infoGeneral)
+        }
+        return accumulator
+    }, [])
+}
+
+export const updateResult = (result, question, percentageConfig) => {
+    return isAClosedTally(question.tally_type)
+    ? updateClosedResult(result, question, percentageConfig)
+    : isARankingTally(question.tally_type) && result
+}

--- a/src/pages/Admin/utils.jsx
+++ b/src/pages/Admin/utils.jsx
@@ -1,3 +1,8 @@
+import {
+  preferentialRankingTallyTypes,
+  firstMajorityTallyTypes,
+} from "../../constants";
+
 export const getPercentage = (frec, total) => {
   if (total === 0) return "0%";
   let dec = (frec / total) * 100;
@@ -36,4 +41,12 @@ export const applyAccent = (word) => {
     }
   }
   return newWord
+}
+
+export const isARankingTally = (tallyType) => {
+  return preferentialRankingTallyTypes.includes(tallyType)
+}
+
+export const isAClosedTally = (tallyType) => {
+  return firstMajorityTallyTypes.includes(tallyType)
 }


### PR DESCRIPTION
# Objetivo
Mostrar resultado de preguntas con ranking preferencial (conjunto de ganadores), de manera diferenciada al resultado de preguntas cerradas.

# Limitaciones
Esta primera versión solo puede obtener un ganador o ganadora.

# Resultado
![Captura de Pantalla 2023-09-20 a la(s) 19 16 04](https://github.com/clcert/psifos-frontend/assets/53621395/c51485b9-d854-4d74-b0ba-bc84703c36fb)

# Testing
Crear una elección que contenga una pregunta con las siguientes características
- Ser una pregunta con ranking preferencial
- No incluir votos nulos ni blancos
- Cantidad máxima de respuesta igual a 6
- 6 opciones de respuestas

Votar
Finalizar la elección
Ver los resultados