### PR TITLE
Mejora interfaz mobile resumen elecciónes

### DIFF
--- a/src/pages/Admin/Home/HomeAdmin.jsx
+++ b/src/pages/Admin/Home/HomeAdmin.jsx
@@ -23,7 +23,7 @@ function HomeAdmin() {
         className="section d-flex justify-content-center is-flex is-vcentered is-centered mt-5 mb-0"
         id="accordion-section"
       >
-        <div>
+        <div className="home-container">
           <Tabs actualTab={actualTab} setActualTab={setActualTab} tabs={tabs} />
           <div className={actualTab !== 0 ? "d-none" : ""}>
             <AccesoElecciones />

--- a/src/pages/Admin/Home/HomeAdmin.jsx
+++ b/src/pages/Admin/Home/HomeAdmin.jsx
@@ -20,10 +20,10 @@ function HomeAdmin() {
       </section>
 
       <section
-        className="section columns is-flex is-vcentered is-centered mt-5 mb-0"
+        className="section d-flex justify-content-center is-flex is-vcentered is-centered mt-5 mb-0"
         id="accordion-section"
       >
-        <div className="chart-container">
+        <div>
           <Tabs actualTab={actualTab} setActualTab={setActualTab} tabs={tabs} />
           <div className={actualTab !== 0 ? "d-none" : ""}>
             <AccesoElecciones />

--- a/src/pages/Admin/Home/ResumenElecciones.jsx
+++ b/src/pages/Admin/Home/ResumenElecciones.jsx
@@ -102,7 +102,7 @@ function ElectionListButton({ isDisabled, onClickHandler, message }) {
   return (
     <div className="d-flex">
       <Button
-        className="button-custom home-admin-button btn-fixed"
+        className="button-custom home-admin-button is-size-7-mobile"
         disabled={isDisabled}
         onClick={onClickHandler}
       >

--- a/src/pages/Admin/Home/component/ResumeTable.jsx
+++ b/src/pages/Admin/Home/component/ResumeTable.jsx
@@ -7,7 +7,7 @@ import { translateStep } from "../../../../utils/utils";
 function StateActionButton({ handler, message }) {
   return (
     <Button
-      className="button-custom home-admin-button btn-fixed"
+      className={`button-custom home-admin-button btn-fixed-mobile is-size-7-mobile`}
       onClick={handler}
     >
       {message}

--- a/src/pages/Admin/Home/component/tasks.jsx
+++ b/src/pages/Admin/Home/component/tasks.jsx
@@ -25,6 +25,9 @@ export const tasks = {
       return await computeTally(shortName);
     },
   },
+  "Computing Tally": {
+    textHelp: "Esperando a que se computen los Tallys",
+  },
   "Tally computed": {
     textHelp: "Esperando a recibir las desencriptaciones",
   },

--- a/src/static/css/booth.css
+++ b/src/static/css/booth.css
@@ -817,6 +817,10 @@ input[type="radio"] {
   width: 60vw;
 }
 
+.home-container{
+  width: 60vw;
+}
+
 .canvas-graph {
   width: 80%;
 }
@@ -828,6 +832,9 @@ input[type="radio"] {
 @media screen and (max-width: 992px) {
   .chart-container {
     width: 80vw;
+  }
+  .home-container{
+    width: 120vw;
   }
   .canvas-graph {
     width: 250%;

--- a/src/static/css/booth.css
+++ b/src/static/css/booth.css
@@ -790,6 +790,12 @@ input[type="radio"] {
   width: 150px;
 }
 
+.btn-fixed-mobile {
+  @media screen and (min-width: 768px) {
+    width: 150px;
+  }
+}
+
 .button-custom {
   background-color: #004c94 !important;
   color: white !important;

--- a/src/utils/utils.jsx
+++ b/src/utils/utils.jsx
@@ -8,6 +8,7 @@ export function translateStep(step) {
     "Setting up": "En configuración",
     "Started": "Iniciada",
     "Ended": "Finalizada",
+    "Computing Tally": "Computando Tally",
     "Tally computed": "Tally computado",
     "Decryptions uploaded": "Desencriptaciones subidas",
     "Decryptions combined": "Desencriptaciones combinadas",


### PR DESCRIPTION
## Titulo
Mejora interfaz mobile resumen elecciónes

## Descripción
Se mejora la vista mobile adjustando el tamaño de los botones y los tamaños de las tablas correspondientes para adaptarse a una vista mobile

# imagenes
## antes
![Captura desde 2024-01-29 13-01-37](https://github.com/clcert/psifos-frontend/assets/32551270/1df0d251-c847-4db3-a8fe-3d45f1410023)
## despues
![Captura desde 2024-01-29 13-02-17](https://github.com/clcert/psifos-frontend/assets/32551270/4f653b76-10df-4c00-b0ae-4bc2860522bb)
