### PR TITLE
feat: responsive statistics

### DIFF
--- a/src/component/Charts/PieChart.jsx
+++ b/src/component/Charts/PieChart.jsx
@@ -10,7 +10,9 @@ const renderChartData = (dataObj) => {
   )
 }
 
-export default function PieChart({ data, legendPosition, chartPosition }) {
+export default function PieChart({
+  data, legendPosition, chartPosition, mediaChartPosition,
+}) {
   const renderedData = renderChartData(data)
   const options = {
       tooltip: {
@@ -22,6 +24,9 @@ export default function PieChart({ data, legendPosition, chartPosition }) {
       },
       series: [
         {
+          label: {
+            show: false,
+          },
           type: 'pie',
           radius: ['30%'],
           color: getGradientPalette(renderedData.length),
@@ -29,6 +34,23 @@ export default function PieChart({ data, legendPosition, chartPosition }) {
           ...chartPosition
         }
       ],
+      media: [
+        {
+          query: { minAspectRatio: 0.5 },
+          option: {
+            series: [
+              chartPosition,
+            ]
+          }
+        },
+        {
+          option: {
+            series: [
+              mediaChartPosition,
+            ]
+          }
+        }
+      ]
   };
   return (
       <ReactEcharts option={options} />

--- a/src/pages/Booth/Panel/statistics/components/statistic.jsx
+++ b/src/pages/Booth/Panel/statistics/components/statistic.jsx
@@ -15,7 +15,7 @@ export default function Statistic({
     title, pieChartData, tableData,
 }) {
     return (
-      <div className="box" style={{width: '100%'}}>
+      <div className="box statistic-container">
         <SectionTitle
           title={title}
         />
@@ -24,13 +24,14 @@ export default function Statistic({
             <PieChart
               data={pieChartData}
               legendPosition={{
-                left: '40%',
-                top: '10%',
-                align: 'left',
-                center: ['20%', '20%'],
+                right: 'right',
+                top: 'center'
               }}
               chartPosition={{
-                center: ['15%', '23%'],
+                center: ['15%', '50%'],
+              }}
+              mediaChartPosition={{
+                center: ['50%', '50%'],
               }}
             />
           </div>

--- a/src/static/assets_home/css/Home.css
+++ b/src/static/assets_home/css/Home.css
@@ -13512,21 +13512,35 @@ Consult
   justify-content: center;
 }
 
+.statistic-container {
+  width: 100%;
+  margin-bottom: 3%;
+}
+
 .statistic-content-container {
   display: flex;
   column-gap: 5px;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .statistic-pie-chart-container {
-  flex-grow: 1;
-  height: 120px;
-  min-width: 300px;
+  position: relative !important;
+  min-width: 260px;
+  overflow: hidden;
+  margin: 5px;
+  padding: 0;
+  height: 100px !important;
+  display: flex;
+  align-items: center;
+
+  .echarts-for-react {
+    width: 100%;
+  }
 }
 
 .statistic-table-container {
   flex-grow: 1;
-  min-width: 300px;
 }
 
 .statistic-header-container {


### PR DESCRIPTION
# Objetivo
Que las estadísticas se vean alineadas, aun si se estén visualizando desde un pc o un celular.

# Estrategia
Modificar las hojas de estilos y los props entregados a la librería que muestra el gráfico de torta.

# Resultado
<img width="185" alt="Captura de Pantalla 2024-06-19 a la(s) 12 21 29" src="https://github.com/clcert/psifos-frontend/assets/53621395/146e64fa-7407-4c51-ba77-dd04fd5a0976">
<img width="1109" alt="Captura de Pantalla 2024-06-19 a la(s) 12 21 44" src="https://github.com/clcert/psifos-frontend/assets/53621395/7fba26b0-de13-4357-89fc-42e77b17d6dc">
