### PR TITLE
Feat/minimal upgrades

### DIFF
--- a/src/pages/Admin/ElectionResume/components/WeightsTable.jsx
+++ b/src/pages/Admin/ElectionResume/components/WeightsTable.jsx
@@ -15,9 +15,9 @@ export default function WeightsTable({
       >
         <Thead>
           <Tr>
-            <Th>PONDERADOR</Th>
-            <Th className="has-text-centered">Votantes en apertura</Th>
-            <Th className="has-text-centered">Votos Recibidos</Th>
+            <Th className="has-text-centered">PONDERADOR</Th>
+            <Th className="has-text-centered">Votantes en padrón</Th>
+            <Th className="has-text-centered">Votos recibidos</Th>
             <Th className="has-text-centered">Votos a contar (1)</Th>
           </Tr>
         </Thead>
@@ -27,18 +27,18 @@ export default function WeightsTable({
             .map((key) => (
               <Tr key={key}>
                 <Td
-                  className="has-text-centered"
+                  className="has-text-centered is-vcentered is-size-5"
                   style={{ backgroundColor: "#009391", color: "white" }}
                 >
-                  {key}
+                  {parseFloat(key).toString().replace(".", ",")}
                 </Td>
-                <Td className="has-text-centered">
+                <Td className="has-text-centered is-vcentered">
                   {weightsInit[key] ? weightsInit[key] : 0}
                 </Td>
-                <Td className="has-text-centered">
+                <Td className="has-text-centered is-vcentered">
                   {weightsEnd[key] ? weightsEnd[key] : 0}
                 </Td>
-                <Td className="has-text-centered">
+                <Td className="has-text-centered is-vcentered">
                   {weightsElection[key] ? weightsElection[key] : 0}
                 </Td>
               </Tr>

--- a/src/pages/Admin/Results/ResultsPerQuestion.jsx
+++ b/src/pages/Admin/Results/ResultsPerQuestion.jsx
@@ -32,7 +32,7 @@ function QuestionTitle({ index, text }) {
   return (
     <div key={index} className="is-size-5 question">
       <span className="has-text-info question-number">
-        Pregunta n°{index + 1}
+        Pregunta #{index + 1}
         {":"}
       </span>
       <div> {text} </div>

--- a/src/pages/Admin/Results/components/PsifosTable.jsx
+++ b/src/pages/Admin/Results/components/PsifosTable.jsx
@@ -62,7 +62,7 @@ function PsifosTable({ data, election }) {
                 <StyledCell
                   key={`row${indexRow}`}
                   content={election.normalization && indexRow === 1
-                    ? parseFloat((fila[row] / election.max_weight)).toFixed(3)
+                    ? parseFloat((fila[row] / election.max_weight)).toString().replace(".", ",")
                     : fila[row]}
                 />
               ))}

--- a/src/pages/Admin/Results/components/PsifosTable.jsx
+++ b/src/pages/Admin/Results/components/PsifosTable.jsx
@@ -63,7 +63,7 @@ function PsifosTable({ data, election }) {
                   key={`row${indexRow}`}
                   content={election.normalization && indexRow === 1
                     ? parseFloat((fila[row] / election.max_weight)).toString().replace(".", ",")
-                    : fila[row]}
+                    : (indexRow === 2 ? fila[row].replace(".", ",") : fila[row])}
                 />
               ))}
             </tr>

--- a/src/pages/Admin/utils.jsx
+++ b/src/pages/Admin/utils.jsx
@@ -9,7 +9,7 @@ export const getPercentage = (frec, total) => {
   /* if (Math.floor(dec) !== Math.ceil(dec)) {
     dec = dec.toFixed(2);
   } */
-  return dec.toFixed(2).toString() + "%";
+  return dec.toFixed(2).toString().replace(".", ",") + "%";
 };
 
 export const getResponseWithoutGroup = (response) => {

--- a/src/pages/Booth/Panel/StatisticsBooth.jsx
+++ b/src/pages/Booth/Panel/StatisticsBooth.jsx
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import Tabs from "../../Admin/component/Tabs";
 import Participation from "./statistics/participation/participation";
-import RollCharacteristics from "./statistics/rollCharacteristics/rollCharacteristics";
-import VotersCharacteristics from "./statistics/votersCharacteristics/votersCharacteristics";
+// import RollCharacteristics from "./statistics/rollCharacteristics/rollCharacteristics";
+// import VotersCharacteristics from "./statistics/votersCharacteristics/votersCharacteristics";
 import VotesByTime from "./statistics/votesByTime/votesByTime";
 import { requestElectionPublic } from "./statistics/components/client";
 
@@ -25,12 +25,12 @@ function StatisticsBooth() {
       shortName={shortName}
       election={election}
     />,
-    "Caracterización del padrón": <RollCharacteristics
-      election={election}
-    />,
-    "Caracterización de los votos recibidos": <VotersCharacteristics
-      election={election}
-    />,
+    // "Caracterización del padrón": <RollCharacteristics
+    //   election={election}
+    // />,
+    // "Caracterización de los votos recibidos": <VotersCharacteristics
+    //   election={election}
+    // />,
     "Distribución de los votos en el tiempo": <VotesByTime
       shortName={shortName}
       election={election}


### PR DESCRIPTION
En este PR hay dos cosas:
1. Ocultar, por el momento, los 2 tabs de Caracterización en el Portal de Información
2. Cambiar los puntos por comas en el despliegue de los resultados (tanto en el número de votos, cuando la elección es ponderada, como en el porcentaje obtenido por cada candidatura)